### PR TITLE
鍵盤の修正とリファクタリング

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,19 +2,26 @@ import React from 'react';
 import { Route, Switch, NavLink } from 'react-router-dom';
 
 import { routes } from './routes';
+import './pages/navigation.css';
 
 export default () => {
   return (
     <>
-      <ul>
+      <ul className="naviList">
         <li>
-          <NavLink to="/">Home</NavLink>
+          <NavLink to="/" className="naviItem">
+            Home
+          </NavLink>
         </li>
         <li>
-          <NavLink to="/question">Question</NavLink>
+          <NavLink to="/question" className="naviItem">
+            Question
+          </NavLink>
         </li>
         <li>
-          <NavLink to="/free">Free</NavLink>
+          <NavLink to="/free" className="naviItem">
+            Free
+          </NavLink>
         </li>
       </ul>
       <Switch>

--- a/src/pages/Absolute.js
+++ b/src/pages/Absolute.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Keyboad } from '../piano/Keyboad';
 import './absolute.css';
 
 export default function Absolute() {
@@ -14,6 +15,7 @@ export default function Absolute() {
       >
         もんだい
       </button>
+      <Keyboad />
     </div>
   );
 }

--- a/src/pages/Absolute.js
+++ b/src/pages/Absolute.js
@@ -1,9 +1,45 @@
 import React from 'react';
 
+import './absolute.css';
+
 export default function Absolute() {
   return (
     <div>
-      <h2>Absolute</h2>
+      <h2>絶対音感クイズ(Absolute)</h2>
+      <button
+        className="button"
+        onClick={() => {
+          QuestionAbsolute();
+        }}
+      >
+        もんだい
+      </button>
     </div>
   );
+}
+
+/*
+- ボタンが押されたらランダムで音を鳴らす、ド～シまで(？
+- 回答者は鍵盤をクリックして答える
+- 鍵盤をクリックすると音が鳴る・・？
+*/
+function QuestionAbsolute() {
+  const keyLevels = [
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+    'a',
+    'b',
+    'cs',
+    'ds',
+    'fs',
+    'gs',
+    'as',
+  ];
+  const level = Math.floor(Math.random() * keyLevels.length);
+  const src = `../src/audio/${keyLevels[level]}3.mp3`;
+  const audio = new Audio(src);
+  audio.play();
 }

--- a/src/pages/Chord.js
+++ b/src/pages/Chord.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Chord() {
+  return (
+    <div>
+      <h2>Chord</h2>
+    </div>
+  );
+}

--- a/src/pages/Free.js
+++ b/src/pages/Free.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import Keyboad from '../piano/Keyboad';
+import { FreeKeyboad } from '../piano/Keyboad';
 
 export default function Free() {
   return (
     <>
       <h2>Fee Play♪</h2>
-      <Keyboad />
+      <FreeKeyboad />
     </>
   );
 }

--- a/src/pages/Question.js
+++ b/src/pages/Question.js
@@ -19,12 +19,12 @@ export default function Question() {
       <ul className="naviList">
         <li>
           <NavLink to={`${match.url}/absolute`} className="naviItem">
-            絶対音感
+            絶対音感(absolute)
           </NavLink>
         </li>
         <li>
           <NavLink to={`${match.url}/relative`} className="naviItem">
-            相対音感
+            相対音感(relative)
           </NavLink>
         </li>
       </ul>

--- a/src/pages/Question.js
+++ b/src/pages/Question.js
@@ -9,17 +9,23 @@ import {
 import Absolute from './Absolute';
 import Relative from './Relative';
 
+import './navigation.css';
+
 export default function Question() {
   let match = useRouteMatch();
   return (
     <div>
       <h2>Question</h2>
-      <ul>
+      <ul className="naviList">
         <li>
-          <NavLink to={`${match.url}/absolute`}>絶対音感</NavLink>
+          <NavLink to={`${match.url}/absolute`} className="naviItem">
+            絶対音感
+          </NavLink>
         </li>
         <li>
-          <NavLink to={`${match.url}/relative`}>相対音感</NavLink>
+          <NavLink to={`${match.url}/relative`} className="naviItem">
+            相対音感
+          </NavLink>
         </li>
       </ul>
       <Switch>

--- a/src/pages/Relative.js
+++ b/src/pages/Relative.js
@@ -1,9 +1,51 @@
 import React from 'react';
+import {
+  Route,
+  Switch,
+  NavLink,
+  useRouteMatch,
+} from 'react-router-dom';
+
+import Basic from './Basic';
+import Easy from './Easy';
+import Chord from './Chord';
 
 export default function Relative() {
+  let match = useRouteMatch();
   return (
     <div>
       <h2>Relative</h2>
+      <ul className="naviList">
+        <li>
+          <NavLink to={`${match.url}/basic`} className="naviItem">
+            単音
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to={`${match.url}/basic/easy`}
+            className="naviItem"
+          >
+            単音(easy)
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to={`${match.url}/chord`} className="naviItem">
+            コード
+          </NavLink>
+        </li>
+      </ul>
+      <Switch>
+        <Route exact path="/question/relative/basic">
+          <Basic />
+        </Route>
+        <Route path="/question/relative/basic/easy">
+          <Easy />
+        </Route>
+        <Route path="/question/relative/chord">
+          <Chord />
+        </Route>
+      </Switch>
     </div>
   );
 }

--- a/src/pages/absolute.css
+++ b/src/pages/absolute.css
@@ -1,0 +1,12 @@
+.button {
+  height: 50px;
+  background: pink;
+  font-size: 15px;
+  text-align: center;
+  vertical-align: middle;
+  border: 2px solid coral;
+}
+
+.button:hover {
+  background: #ffefeb;
+}

--- a/src/pages/navigation.css
+++ b/src/pages/navigation.css
@@ -1,0 +1,18 @@
+.naviList {
+  display: flex;
+  list-style: none;
+  padding: 0;
+}
+
+.naviItem {
+  background: #ddd;
+  color: black;
+  font-size: 20px;
+  margin-right: 10px;
+  padding: 10px;
+  text-decoration: none;
+}
+
+.naviItem:hover {
+  background: #eee;
+}

--- a/src/piano/Keyboad.js
+++ b/src/piano/Keyboad.js
@@ -86,23 +86,24 @@ export default function Keyboad() {
     const src = `./src/audio/c7.mp3`;
     const audio = new Audio(src);
     whiteKeys.push(
-      <>
-        <rect
-          x={whiteX}
-          y={whiteY}
-          width={whiteWidth}
-          height={whiteHeight}
-          className="white"
-          onMouseDown={() => {
-            PlayPiano(audio);
-          }}
-        />
-        <text x={textX} y={textY} className="text">
-          C{7}
-        </text>
-      </>
+      <rect
+        x={whiteX}
+        y={whiteY}
+        width={whiteWidth}
+        height={whiteHeight}
+        className="white"
+        onMouseDown={() => {
+          PlayPiano(audio);
+        }}
+      />
     );
     whiteX = whiteX + 80;
+
+    keyTexts.push(
+      <text x={textX} y={textY} className="text">
+        C{7}
+      </text>
+    );
   }
 
   const svgWidth = whiteX + 2;

--- a/src/piano/Keyboad.js
+++ b/src/piano/Keyboad.js
@@ -6,6 +6,61 @@ import './Keyboad.css';
 黒鍵：50*225, 5こ, (40,100,35,35,50)
 */
 
+export function Keyboad() {
+  let whiteKeys = [];
+  let whiteX = 0;
+  const whiteWidth = 80;
+  const whiteHeight = 405;
+  for (let i = 0; i < 7; i++) {
+    const whiteKey = (
+      <rect
+        x={whiteX}
+        y={0}
+        width={whiteWidth}
+        height={whiteHeight}
+        className="white"
+      />
+    );
+    whiteKeys.push(whiteKey);
+    whiteX = whiteX + 80;
+  }
+
+  let blackKeys = [];
+  let blackX = 0;
+  const blackWidth = 50;
+  const blackHeight = 225;
+  const spase = [40, 100, 35, 35, 50];
+  blackX = blackX + 50;
+  for (let i = 0; i < 5; i++) {
+    const blackKey = (
+      <rect
+        x={blackX}
+        y={0}
+        width={blackWidth}
+        height={blackHeight}
+        className="black"
+      />
+    );
+    blackKeys.push(blackKey);
+    blackX = blackX + 50 + spase[i];
+  }
+
+  const svgWidth = whiteX + 2;
+  const svgHeight = whiteHeight + 2;
+  return (
+    <div className="keyboad">
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        viewBox={`-1 -1 ${svgWidth} ${svgHeight}`}
+      >
+        {whiteKeys}
+        {blackKeys}
+      </svg>
+    </div>
+  );
+}
+
 export function FreeKeyboad() {
   let whiteKeys = [];
   let whiteX = 0;
@@ -17,7 +72,6 @@ export function FreeKeyboad() {
     for (let i = 0; i < 7; i++) {
       const src = `./src/audio/${whiteKeyLevel[i]}${octave}.mp3`;
       const audio = new Audio(src);
-
       const whiteKey = (
         <rect
           x={whiteX}
@@ -62,7 +116,6 @@ export function FreeKeyboad() {
     for (let i = 0; i < 5; i++) {
       const src = `./src/audio/${blackKeyLevel[i]}s${octave}.mp3`;
       const audio = new Audio(src);
-
       const blackKey = (
         <rect
           x={blackX}
@@ -92,7 +145,6 @@ export function FreeKeyboad() {
     keyTexts.push(keyText);
     textX = textX + 560;
   }
-
   keyTexts.push(
     <text x={textX} y={textY} className="text">
       C{7}

--- a/src/piano/Keyboad.js
+++ b/src/piano/Keyboad.js
@@ -6,19 +6,31 @@ import './Keyboad.css';
 黒鍵：50*225, 5こ, (40,100,35,35,50)
 */
 
+const OCTAVE_NUM = 7;
+const WHITE_KEY_NUM = 7;
+const BLUCK_KEY_NUM = 5;
+
+const WHITE_KEY_WIDTH = 80;
+const WHITE_KEY_HEIGHT = 405;
+const WHITE_KEY_LEVEL = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
+
+const BLACK_KEY_WIDTH = 50;
+const BLACK_KEY_HEIGHT = 225;
+const BLACK_KEY_SPASE = [40, 100, 35, 35, 50];
+const BLACK_KEY_LEVEL = ['cs', 'ds', 'fs', 'gs', 'as'];
+
 export function Keyboad() {
   let whiteKeys = [];
   let whiteX = 0;
-  const whiteWidth = 80;
-  const whiteHeight = 405;
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < WHITE_KEY_NUM; i++) {
     const whiteKey = (
       <rect
         x={whiteX}
         y={0}
-        width={whiteWidth}
-        height={whiteHeight}
+        width={WHITE_KEY_WIDTH}
+        height={WHITE_KEY_HEIGHT}
         className="white"
+        id={`${WHITE_KEY_LEVEL[i]}3`}
       />
     );
     whiteKeys.push(whiteKey);
@@ -27,26 +39,24 @@ export function Keyboad() {
 
   let blackKeys = [];
   let blackX = 0;
-  const blackWidth = 50;
-  const blackHeight = 225;
-  const spase = [40, 100, 35, 35, 50];
-  blackX = blackX + 50;
-  for (let i = 0; i < 5; i++) {
+  blackX = blackX + BLACK_KEY_WIDTH;
+  for (let i = 0; i < BLUCK_KEY_NUM; i++) {
     const blackKey = (
       <rect
         x={blackX}
         y={0}
-        width={blackWidth}
-        height={blackHeight}
+        width={BLACK_KEY_WIDTH}
+        height={BLACK_KEY_HEIGHT}
         className="black"
+        id={`${BLACK_KEY_LEVEL[i]}3`}
       />
     );
     blackKeys.push(blackKey);
-    blackX = blackX + 50 + spase[i];
+    blackX = blackX + BLACK_KEY_WIDTH + BLACK_KEY_SPASE[i];
   }
 
   const svgWidth = whiteX + 2;
-  const svgHeight = whiteHeight + 2;
+  const svgHeight = WHITE_KEY_HEIGHT + 2;
   return (
     <div className="keyboad">
       <svg
@@ -64,20 +74,17 @@ export function Keyboad() {
 export function FreeKeyboad() {
   let whiteKeys = [];
   let whiteX = 0;
-  const whiteWidth = 80;
-  const whiteHeight = 405;
-  const whiteKeyLevel = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < OCTAVE_NUM; i++) {
     let octave = i;
-    for (let i = 0; i < 7; i++) {
-      const src = `./src/audio/${whiteKeyLevel[i]}${octave}.mp3`;
+    for (let i = 0; i < WHITE_KEY_NUM; i++) {
+      const src = `./src/audio/${WHITE_KEY_LEVEL[i]}${octave}.mp3`;
       const audio = new Audio(src);
       const whiteKey = (
         <rect
           x={whiteX}
           y={0}
-          width={whiteWidth}
-          height={whiteHeight}
+          width={WHITE_KEY_WIDTH}
+          height={WHITE_KEY_HEIGHT}
           className="white"
           onMouseDown={() => {
             PlayPiano(audio);
@@ -94,8 +101,8 @@ export function FreeKeyboad() {
     <rect
       x={whiteX}
       y={0}
-      width={whiteWidth}
-      height={whiteHeight}
+      width={WHITE_KEY_WIDTH}
+      height={WHITE_KEY_HEIGHT}
       className="white"
       onMouseDown={() => {
         PlayPiano(audio);
@@ -106,22 +113,18 @@ export function FreeKeyboad() {
 
   let blackKeys = [];
   let blackX = 0;
-  const blackWidth = 50;
-  const blackHeight = 225;
-  const spase = [40, 100, 35, 35, 50];
-  const blackKeyLevel = ['c', 'd', 'f', 'g', 'a'];
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < OCTAVE_NUM; i++) {
     let octave = i;
-    blackX = blackX + 50;
-    for (let i = 0; i < 5; i++) {
-      const src = `./src/audio/${blackKeyLevel[i]}s${octave}.mp3`;
+    blackX = blackX + BLACK_KEY_WIDTH;
+    for (let i = 0; i < BLUCK_KEY_NUM; i++) {
+      const src = `./src/audio/${BLACK_KEY_LEVEL[i]}${octave}.mp3`;
       const audio = new Audio(src);
       const blackKey = (
         <rect
           x={blackX}
           y={0}
-          width={blackWidth}
-          height={blackHeight}
+          width={BLACK_KEY_WIDTH}
+          height={BLACK_KEY_HEIGHT}
           className="black"
           onMouseDown={() => {
             PlayPiano(audio);
@@ -129,37 +132,32 @@ export function FreeKeyboad() {
         />
       );
       blackKeys.push(blackKey);
-      blackX = blackX + 50 + spase[i];
+      blackX = blackX + BLACK_KEY_WIDTH + BLACK_KEY_SPASE[i];
     }
   }
 
   let keyTexts = [];
   let textX = 20;
-  const textY = 380;
-  for (let i = 0; i < 7; i++) {
+  const TEXT_Y = 380;
+  for (let i = 0; i <= OCTAVE_NUM; i++) {
     const keyText = (
-      <text x={textX} y={textY} className="text">
+      <text x={textX} y={TEXT_Y} className="text">
         C{i}
       </text>
     );
     keyTexts.push(keyText);
     textX = textX + 560;
   }
-  keyTexts.push(
-    <text x={textX} y={textY} className="text">
-      C{7}
-    </text>
-  );
 
-  const svgWidth = whiteX + 2;
-  const svgHeight = whiteHeight + 2;
+  const SVG_WIDTH = whiteX + 2;
+  const SVG_HEIGHT = WHITE_KEY_HEIGHT + 2;
 
   return (
     <div className="keyboad">
       <svg
-        width={svgWidth}
-        height={svgHeight}
-        viewBox={`-1 -1 ${svgWidth} ${svgHeight}`}
+        width={SVG_WIDTH}
+        height={SVG_HEIGHT}
+        viewBox={`-1 -1 ${SVG_WIDTH} ${SVG_HEIGHT}`}
       >
         {whiteKeys}
         {blackKeys}

--- a/src/piano/Keyboad.js
+++ b/src/piano/Keyboad.js
@@ -6,16 +6,13 @@ import './Keyboad.css';
 黒鍵：50*225, 5こ, (40,100,35,35,50)
 */
 
-export default function Keyboad() {
-  const keyboadLength = 7;
-
+export function FreeKeyboad() {
   let whiteKeys = [];
   let whiteX = 0;
-  const whiteY = 0;
   const whiteWidth = 80;
   const whiteHeight = 405;
   const whiteKeyLevel = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
-  for (let i = 0; i < keyboadLength; i++) {
+  for (let i = 0; i < 7; i++) {
     let octave = i;
     for (let i = 0; i < 7; i++) {
       const src = `./src/audio/${whiteKeyLevel[i]}${octave}.mp3`;
@@ -24,7 +21,7 @@ export default function Keyboad() {
       const whiteKey = (
         <rect
           x={whiteX}
-          y={whiteY}
+          y={0}
           width={whiteWidth}
           height={whiteHeight}
           className="white"
@@ -37,15 +34,29 @@ export default function Keyboad() {
       whiteX = whiteX + 80;
     }
   }
+  const src = `./src/audio/c7.mp3`;
+  const audio = new Audio(src);
+  whiteKeys.push(
+    <rect
+      x={whiteX}
+      y={0}
+      width={whiteWidth}
+      height={whiteHeight}
+      className="white"
+      onMouseDown={() => {
+        PlayPiano(audio);
+      }}
+    />
+  );
+  whiteX = whiteX + 80;
 
   let blackKeys = [];
   let blackX = 0;
-  const blackY = 0;
   const blackWidth = 50;
   const blackHeight = 225;
   const spase = [40, 100, 35, 35, 50];
   const blackKeyLevel = ['c', 'd', 'f', 'g', 'a'];
-  for (let i = 0; i < keyboadLength; i++) {
+  for (let i = 0; i < 7; i++) {
     let octave = i;
     blackX = blackX + 50;
     for (let i = 0; i < 5; i++) {
@@ -55,7 +66,7 @@ export default function Keyboad() {
       const blackKey = (
         <rect
           x={blackX}
-          y={blackY}
+          y={0}
           width={blackWidth}
           height={blackHeight}
           className="black"
@@ -72,7 +83,7 @@ export default function Keyboad() {
   let keyTexts = [];
   let textX = 20;
   const textY = 380;
-  for (let i = 0; i < keyboadLength; i++) {
+  for (let i = 0; i < 7; i++) {
     const keyText = (
       <text x={textX} y={textY} className="text">
         C{i}
@@ -82,29 +93,11 @@ export default function Keyboad() {
     textX = textX + 560;
   }
 
-  if (keyboadLength === 7) {
-    const src = `./src/audio/c7.mp3`;
-    const audio = new Audio(src);
-    whiteKeys.push(
-      <rect
-        x={whiteX}
-        y={whiteY}
-        width={whiteWidth}
-        height={whiteHeight}
-        className="white"
-        onMouseDown={() => {
-          PlayPiano(audio);
-        }}
-      />
-    );
-    whiteX = whiteX + 80;
-
-    keyTexts.push(
-      <text x={textX} y={textY} className="text">
-        C{7}
-      </text>
-    );
-  }
+  keyTexts.push(
+    <text x={textX} y={textY} className="text">
+      C{7}
+    </text>
+  );
 
   const svgWidth = whiteX + 2;
   const svgHeight = whiteHeight + 2;


### PR DESCRIPTION
## 鍵盤の修正
- C7のキーとテキストを別々の配列にpushするよう変更しました。
- フリー演奏用の鍵盤を生成する関数から、鍵盤の幅や高さなどの定数を外に出して、他の関数でも使えるように変更しました。
- クイズ回答用の鍵盤を新しく作成しました。


## その他の変更点
- 各ページ共通のナビゲーションに、とりあえず見やすいようにcssをつけました。
- 絶対音感クイズのページもルーティングしました。
- 絶対音感クイズのページに、とりあえずでランダムに音が鳴るボタンを設置しました。