### PR TITLE
クイズ終了時に結果画面を表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "redux-thunk": "^2.3.0"
   }
 }

--- a/src/pages/Absolute/Absolute.js
+++ b/src/pages/Absolute/Absolute.js
@@ -1,23 +1,18 @@
 import React from 'react';
 
-import { askQuestions, correctAnswer, wrongAnswer } from '../../redux/action';
+import {
+  askQuestions,
+  correctAnswer,
+  wrongAnswer,
+  endQuestion,
+  oneMore,
+} from '../../redux/action';
 import { Keyboad } from '../../piano/Keyboad';
 import './absolute.css';
 
-const keyLevels = [
-  'c',
-  'd',
-  'e',
-  'f',
-  'g',
-  'a',
-  'b',
-  'cs',
-  'ds',
-  'fs',
-  'gs',
-  'as',
-];
+import { KEY_LEVELS } from '../../piano/constant';
+
+const QUESTION_NUM = 10;
 
 export class Absolute extends React.Component {
   constructor(props) {
@@ -27,9 +22,9 @@ export class Absolute extends React.Component {
   }
 
   randomPlay() {
-    if (!this.props.isQuestion) {
-      const n = Math.floor(Math.random() * keyLevels.length);
-      const correctKey = `${keyLevels[n]}3`;
+    if (!this.props.isAskingQuestion) {
+      const n = Math.floor(Math.random() * KEY_LEVELS.length);
+      const correctKey = `${KEY_LEVELS[n]}3`;
       const src = `../src/audio/${correctKey}.mp3`;
       const audio = new Audio(src);
       audio.play();
@@ -38,15 +33,18 @@ export class Absolute extends React.Component {
   }
 
   judgment(keyName) {
-    if (this.props.isQuestion) {
-      const src = `../src/audio/${keyName}.mp3`;
-      const audio = new Audio(src);
-      audio.play();
+    const src = `../src/audio/${keyName}.mp3`;
+    const audio = new Audio(src);
+    audio.play();
+    if (this.props.isAskingQuestion) {
       if (keyName === this.props.correctKey) {
         this.props.dispatch(correctAnswer());
       } else {
         this.props.dispatch(wrongAnswer());
       }
+    }
+    if (this.props.questionNum === QUESTION_NUM - 1) {
+      this.props.dispatch(endQuestion());
     }
   }
 
@@ -54,17 +52,41 @@ export class Absolute extends React.Component {
     return (
       <div>
         <h2>絶対音感クイズ(Absolute)</h2>
-        <button
-          className="button"
-          onClick={() => {
-            this.randomPlay();
-          }}
-        >
-          もんだい
-        </button>
-        <span className="texts">{`判定 -> ${this.props.judgment}`}</span>
-        <span className="texts">{`正答数 -> ${this.props.correctAnswer}`}</span>
-        <Keyboad judgment={this.judgment} />
+        {this.props.endQuenstion ? (
+          <>
+            <p>結果は・・・</p>
+            <p>{`10問中 ${this.props.correctAnswer}問正解！`}</p>
+            <button
+              className="oneMore"
+              onClick={() => {
+                this.props.dispatch(oneMore());
+              }}
+            >
+              もう一回
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              className="button"
+              onClick={() => {
+                this.randomPlay();
+              }}
+            >
+              もんだい
+            </button>
+
+            <span className="texts">{`${this.props.judgment}`}</span>
+            {this.props.isAskingQuestion ? (
+              <span className="texts">正解は ...</span>
+            ) : (
+              <span className="texts">{`正解は ${this.props.correctKey}`}</span>
+            )}
+            <span className="texts">{`正答数 -> ${this.props.correctAnswer}`}</span>
+
+            <Keyboad judgment={this.judgment} />
+          </>
+        )}
       </div>
     );
   }

--- a/src/pages/Absolute/absolute.css
+++ b/src/pages/Absolute/absolute.css
@@ -15,5 +15,15 @@
 .texts {
   display: inline-block;
   margin: 10px;
-  width: 200px;
+  width: 100px;
+}
+
+.oneMore {
+  height: 50px;
+  background: pink;
+  font-size: 15px;
+  text-align: center;
+  vertical-align: middle;
+  border: 2px solid coral;
+  margin: 30px;
 }

--- a/src/pages/Absolute/index.js
+++ b/src/pages/Absolute/index.js
@@ -2,8 +2,22 @@ import { Absolute } from './Absolute';
 import { connect } from 'react-redux';
 
 const mapStateToProps = (state) => {
-  const { correctAnswer, correctKey, isQuestion, judgment } = state;
-  return { correctAnswer, correctKey, isQuestion, judgment };
+  const {
+    correctAnswer,
+    correctKey,
+    isAskingQuestion,
+    judgment,
+    questionNum,
+    endQuenstion,
+  } = state;
+  return {
+    correctAnswer,
+    correctKey,
+    isAskingQuestion,
+    judgment,
+    questionNum,
+    endQuenstion,
+  };
 };
 const ConnectedAbsolute = connect(mapStateToProps)(Absolute);
 

--- a/src/piano/Keyboad.js
+++ b/src/piano/Keyboad.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import './keyboad.css';
 
-const OCTAVE_NUM = 7;
-const WHITE_KEY_NUM = 7;
-const BLUCK_KEY_NUM = 5;
-
-const WHITE_KEY_WIDTH = 80;
-const WHITE_KEY_HEIGHT = 405;
-const WHITE_KEY_LEVEL = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
-
-const BLACK_KEY_WIDTH = 50;
-const BLACK_KEY_HEIGHT = 225;
-const BLACK_KEY_SPASE = [40, 100, 35, 35, 50];
-const BLACK_KEY_LEVEL = ['cs', 'ds', 'fs', 'gs', 'as'];
+import {
+  OCTAVE_NUM,
+  WHITE_KEY_NUM,
+  BLUCK_KEY_NUM,
+  WHITE_KEY_WIDTH,
+  WHITE_KEY_HEIGHT,
+  WHITE_KEY_LEVEL,
+  BLACK_KEY_WIDTH,
+  BLACK_KEY_HEIGHT,
+  BLACK_KEY_SPASE,
+  BLACK_KEY_LEVEL,
+} from './constant';
 
 export function Keyboad(props) {
   let whiteKeys = [];

--- a/src/piano/constant.js
+++ b/src/piano/constant.js
@@ -15,3 +15,18 @@ export const BLACK_KEY_WIDTH = 50;
 export const BLACK_KEY_HEIGHT = 225;
 export const BLACK_KEY_SPASE = [40, 100, 35, 35, 50];
 export const BLACK_KEY_LEVEL = ['cs', 'ds', 'fs', 'gs', 'as'];
+
+export const KEY_LEVELS = [
+  'c',
+  'd',
+  'e',
+  'f',
+  'g',
+  'a',
+  'b',
+  'cs',
+  'ds',
+  'fs',
+  'gs',
+  'as',
+];

--- a/src/redux/action.js
+++ b/src/redux/action.js
@@ -1,10 +1,19 @@
-export const AUK_QUESTIONS = 'AUK_QUESTIONS';
+export const INITIAL_AUDIO = 'INITIAL_AUDIO';
+export const ASK_QUESTIONS = 'ASK_QUESTIONS';
 export const CORRECT_ANSWER = 'CORRECT_ANSWER';
 export const WRONG_ANSWER = 'WRONG_ANSWER';
+export const END_QUENSTION = 'END_QUENSTION';
+export const ONE_MORE_PLAY = 'ONE_MORE_PLAY';
+
+export const initialAudio = () => {
+  return {
+    type: INITIAL_AUDIO,
+  };
+};
 
 export const askQuestions = (correctKey) => {
   return {
-    type: AUK_QUESTIONS,
+    type: ASK_QUESTIONS,
     payload: {
       correctKey,
     },
@@ -20,5 +29,17 @@ export const correctAnswer = () => {
 export const wrongAnswer = () => {
   return {
     type: WRONG_ANSWER,
+  };
+};
+
+export const endQuestion = () => {
+  return {
+    type: END_QUENSTION,
+  };
+};
+
+export const oneMore = () => {
+  return {
+    type: ONE_MORE_PLAY,
   };
 };

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,36 +1,76 @@
-import { AUK_QUESTIONS, CORRECT_ANSWER, WRONG_ANSWER } from './action';
+import {
+  ASK_QUESTIONS,
+  CORRECT_ANSWER,
+  WRONG_ANSWER,
+  END_QUENSTION,
+  ONE_MORE_PLAY,
+  INITIAL_AUDIO,
+} from './action';
 
 const initialState = {
   correctAnswer: 0,
   correctKey: '',
-  isQuestion: false,
+  isAskingQuestion: false,
   judgment: '',
+  questionNum: 0,
+  endQuenstion: false,
 };
 
 export default function answer(state = initialState, action) {
   switch (action.type) {
-    case AUK_QUESTIONS:
+    case INITIAL_AUDIO: {
+      const audio = new Audio();
+      audio.addEventListener();
+      audio.src = '';
+      return {
+        ...state,
+      };
+    }
+    case ASK_QUESTIONS: {
       const correctKey = action.payload.correctKey;
       return {
         ...state,
         correctKey: correctKey,
-        isQuestion: true,
+        isAskingQuestion: true,
         judgment: '',
       };
-    case CORRECT_ANSWER:
-      const incrementAnswer = state.correctAnswer + 1;
+    }
+    case CORRECT_ANSWER: {
+      const questionNum = state.questionNum + 1;
+      const correctAnswer = state.correctAnswer + 1;
       return {
         ...state,
-        correctAnswer: incrementAnswer,
-        isQuestion: false,
+        correctAnswer: correctAnswer,
+        isAskingQuestion: false,
         judgment: '正解',
+        questionNum: questionNum,
       };
-    case WRONG_ANSWER:
+    }
+    case WRONG_ANSWER: {
+      const questionNum = state.questionNum + 1;
       return {
         ...state,
-        isQuestion: false,
+        isAskingQuestion: false,
         judgment: '不正解',
+        questionNum: questionNum,
       };
+    }
+    case END_QUENSTION: {
+      return {
+        ...state,
+        endQuenstion: true,
+      };
+    }
+    case ONE_MORE_PLAY: {
+      return {
+        correctAnswer: 0,
+        correctKey: '',
+        isAskingQuestion: false,
+        judgment: '',
+        questionNum: 0,
+        endQuenstion: false,
+      };
+    }
     default:
       return state;
   }

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,9 +1,8 @@
-import { createStore } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
 import reducer from './reducer';
 
-const store = createStore(
-  reducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-);
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(reducer, composeEnhancers(applyMiddleware(thunk)));
 
 export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,6 +4445,11 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"


### PR DESCRIPTION
## 機能
- 10問目を解答するとリザルト画面になる。
- リザルトでは正答数と「もう一回遊ぶボタン」を表示。
- もう一回遊ぶボタンを押すと、最初の状態に戻り、もう一度クイズに挑戦できる。


## その他の変更
- 解答の正誤とは別に、正答の表示を追加。

- redux-thunkを追加。
- ピアノ鍵盤で使っている定数を別ファイルから読み込むように変更。